### PR TITLE
voting_rewards: gate emissions by marketkeys whitelisted_for_rewards flag

### DIFF
--- a/aqua_voting_tracker/voting/marketkeys/requests.py
+++ b/aqua_voting_tracker/voting/marketkeys/requests.py
@@ -51,9 +51,6 @@ class ApiMarketKeysProvider(BaseMarketKeysProvider):
                 else:
                     downvotes_account_ids.add(market_key['downvote_account_id'])
 
-                if market_key['is_banned']:
-                    continue
-
                 yield market_key
 
             not_found_ids.extend(chunk)
@@ -67,7 +64,4 @@ class ApiMarketKeysProvider(BaseMarketKeysProvider):
             response.raise_for_status()
 
             for market_key in response.json()['results']:
-                if market_key['is_banned']:
-                    continue
-
                 yield market_key

--- a/aqua_voting_tracker/voting_rewards/services/rewards/base.py
+++ b/aqua_voting_tracker/voting_rewards/services/rewards/base.py
@@ -15,6 +15,8 @@ class MarketReward:
     asset1: str = None
     asset2: str = None
 
+    whitelisted_for_rewards: bool = False
+
     share: Decimal = None
     reward_value: Decimal = None
 
@@ -49,15 +51,24 @@ class RewardsCalculator:
         reward_zone = list(reward_zone)
         market_pairs = get_market_pairs((market.market_key for market in reward_zone))
         market_pair_mapping = {
-            market_pair['account_id']: (market_pair['asset1'], market_pair['asset2'])
+            market_pair['account_id']: market_pair
             for market_pair in market_pairs
         }
 
         for market_reward in reward_zone:
-            asset1, asset2 = market_pair_mapping[market_reward.market_key]
-            market_reward.asset1 = asset1
-            market_reward.asset2 = asset2
+            market_pair = market_pair_mapping[market_reward.market_key]
+            market_reward.asset1 = market_pair['asset1']
+            market_reward.asset2 = market_pair['asset2']
+            market_reward.whitelisted_for_rewards = bool(market_pair.get('whitelisted_for_rewards'))
 
+            yield market_reward
+
+    def filter_eligible(self, reward_zone: Iterable[MarketReward]) -> Iterable[MarketReward]:
+        # Drop markets whose pair is not whitelisted for rewards. Runs after
+        # calculate_shares so dropped shares are not redistributed to survivors.
+        for market_reward in reward_zone:
+            if not market_reward.whitelisted_for_rewards:
+                continue
             yield market_reward
 
     def calculate_shares(self, reward_zone: Iterable[MarketReward]) -> Iterable[MarketReward]:
@@ -83,11 +94,11 @@ class RewardsCalculator:
             yield market_reward
 
     def set_reward_value(self, reward_zone: Iterable[MarketReward]) -> Iterable[MarketReward]:
-        reward_zone = list(reward_zone)
-        total_share = sum(market.share for market in reward_zone)
-
+        # No /total_share renormalization: per-pair cap stays absolute at
+        # REWARD_MAX_SHARE * TOTAL_REWARDS, and total dispersion across survivors
+        # can be < TOTAL_REWARDS when filter_eligible has dropped any markets.
         for market_reward in reward_zone:
-            market_reward.reward_value = round(self.TOTAL_REWARDS * market_reward.share / total_share)
+            market_reward.reward_value = round(self.TOTAL_REWARDS * market_reward.share)
             market_reward.share = Decimal(round(market_reward.share, 4))
 
             yield market_reward

--- a/aqua_voting_tracker/voting_rewards/services/rewards/base.py
+++ b/aqua_voting_tracker/voting_rewards/services/rewards/base.py
@@ -64,8 +64,10 @@ class RewardsCalculator:
             yield market_reward
 
     def filter_eligible(self, reward_zone: Iterable[MarketReward]) -> Iterable[MarketReward]:
-        # Drop markets whose pair is not whitelisted for rewards. Runs after
-        # calculate_shares so dropped shares are not redistributed to survivors.
+        # Drop markets whose pair is not whitelisted for rewards. Runs before
+        # calculate_shares so the share denominator is restricted to survivors —
+        # when there are few enough survivors, each naturally lifts to the
+        # REWARD_MAX_SHARE cap via cap+redistribute.
         for market_reward in reward_zone:
             if not market_reward.whitelisted_for_rewards:
                 continue
@@ -95,8 +97,9 @@ class RewardsCalculator:
 
     def set_reward_value(self, reward_zone: Iterable[MarketReward]) -> Iterable[MarketReward]:
         # No /total_share renormalization: per-pair cap stays absolute at
-        # REWARD_MAX_SHARE * TOTAL_REWARDS, and total dispersion across survivors
-        # can be < TOTAL_REWARDS when filter_eligible has dropped any markets.
+        # REWARD_MAX_SHARE * TOTAL_REWARDS, and total dispersion falls below
+        # TOTAL_REWARDS whenever cap+redistribute leaves any residue (e.g. with
+        # few enough survivors that everyone hits the cap).
         for market_reward in reward_zone:
             market_reward.reward_value = round(self.TOTAL_REWARDS * market_reward.share)
             market_reward.share = Decimal(round(market_reward.share, 4))

--- a/aqua_voting_tracker/voting_rewards/services/rewards/v1.py
+++ b/aqua_voting_tracker/voting_rewards/services/rewards/v1.py
@@ -27,6 +27,7 @@ class RewardsV1Calculator(RewardsCalculator):
         reward_zone = self.get_reward_zone()
         reward_zone = self.connect_assets(reward_zone)
         reward_zone = self.calculate_shares(reward_zone)
+        reward_zone = self.filter_eligible(reward_zone)
         reward_zone = self.set_reward_value(reward_zone)
         reward_zone = self.distribute_sdex_amm_rewards(reward_zone)
         return list(reward_zone)

--- a/aqua_voting_tracker/voting_rewards/services/rewards/v1.py
+++ b/aqua_voting_tracker/voting_rewards/services/rewards/v1.py
@@ -26,8 +26,8 @@ class RewardsV1Calculator(RewardsCalculator):
     def run(self) -> List[MarketReward]:
         reward_zone = self.get_reward_zone()
         reward_zone = self.connect_assets(reward_zone)
-        reward_zone = self.calculate_shares(reward_zone)
         reward_zone = self.filter_eligible(reward_zone)
+        reward_zone = self.calculate_shares(reward_zone)
         reward_zone = self.set_reward_value(reward_zone)
         reward_zone = self.distribute_sdex_amm_rewards(reward_zone)
         return list(reward_zone)

--- a/aqua_voting_tracker/voting_rewards/services/rewards/v2.py
+++ b/aqua_voting_tracker/voting_rewards/services/rewards/v2.py
@@ -80,8 +80,8 @@ class RewardsV2Calculator(RewardsCalculator):
     def run(self) -> List[MarketReward]:
         reward_zone = self.get_reward_zone()
         reward_zone = self.connect_assets(reward_zone)
-        reward_zone = self.calculate_shares(reward_zone)
         reward_zone = self.filter_eligible(reward_zone)
+        reward_zone = self.calculate_shares(reward_zone)
         reward_zone = self.set_reward_value(reward_zone)
         reward_zone = self.distribute_sdex_amm(reward_zone)
         return list(reward_zone)

--- a/aqua_voting_tracker/voting_rewards/services/rewards/v2.py
+++ b/aqua_voting_tracker/voting_rewards/services/rewards/v2.py
@@ -81,6 +81,7 @@ class RewardsV2Calculator(RewardsCalculator):
         reward_zone = self.get_reward_zone()
         reward_zone = self.connect_assets(reward_zone)
         reward_zone = self.calculate_shares(reward_zone)
+        reward_zone = self.filter_eligible(reward_zone)
         reward_zone = self.set_reward_value(reward_zone)
         reward_zone = self.distribute_sdex_amm(reward_zone)
         return list(reward_zone)

--- a/aqua_voting_tracker/voting_rewards/tests/test_rewards.py
+++ b/aqua_voting_tracker/voting_rewards/tests/test_rewards.py
@@ -133,15 +133,16 @@ class GetCurrentRewardTestCase(TestCase):
             '0.0303', '0.0303', '0.0303', '0.0303', '0.0303', '0.0303', '0.0152', '0.0152', '0.0152',
         ])
 
-    def test_whitelist_dilution(self):
-        # Non-whitelisted markets do not get rewards and their shares are NOT
-        # redistributed to survivors — total dispersion drops by their combined share.
+    def test_whitelist_few_survivors_lift_to_cap(self):
+        # With filter_eligible running before calculate_shares, the share denominator
+        # is restricted to survivors. When ≤10 survivors pass through, each base
+        # share (votes / survivors_votes) is large enough to hit REWARD_MAX_SHARE
+        # and cap+redistribute lifts everyone to the cap. Total reward = N * cap *
+        # TOTAL_REWARDS, with cap residue lost (no upward normalization).
         candidates = get_candidates([95, 90, 85, 80, 75, 70, 65, 60, 55, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10])
-        stats = get_stats(candidates)  # full_voting_value = 1000
+        stats = get_stats(candidates)
 
-        # Whitelist first 5 markets only: survivors_votes = 95+90+85+80+75 = 425, dilution = 0.425.
         whitelist_flags = [True] * 5 + [False] * 14
-        survivors_share = Decimal('0.425')
 
         with patch(self.get_candidates_patch, new=lambda x: candidates):
             with patch(self.get_stats_patch, new=lambda: stats):
@@ -153,20 +154,19 @@ class GetCurrentRewardTestCase(TestCase):
 
         self.assertEqual(len(rewards), 5)
 
-        # Per-pair share = votes / full_voting_value (no /total_share renormalization).
-        self.assert_shares(rewards, ['0.095', '0.09', '0.085', '0.08', '0.075'])
+        # Survivors votes = 95+90+85+80+75 = 425, denominator = 425.
+        # Each base share > 0.176 — all exceed REWARD_MAX_SHARE; cap+redistribute
+        # lifts every survivor to 0.1.
+        self.assert_shares(rewards, ['0.1', '0.1', '0.1', '0.1', '0.1'])
 
-        # Total dispersion = TOTAL_REWARDS * survivors_share (≈ 0.425 * 7M).
+        # Total = 5 * 700k = 3.5M. Cap residue (0.5) is lost.
         total_reward = sum(reward.reward_value for reward in rewards)
         self.assertAlmostEqual(
             total_reward,
-            settings.TOTAL_REWARD_VALUE * survivors_share,
+            settings.TOTAL_REWARD_VALUE * Decimal('0.5'),
             delta=5,
         )
         self.assertLessEqual(total_reward, settings.TOTAL_REWARD_VALUE)
-
-        # Per-pair cap is absolute (REWARD_MAX_SHARE * TOTAL_REWARDS = 700k), not relative.
-        self.assertTrue(all(reward.share <= settings.REWARD_MAX_SHARE for reward in rewards))
         self.assertTrue(all(
             reward.reward_value <= settings.REWARD_MAX_SHARE * settings.TOTAL_REWARD_VALUE
             for reward in rewards

--- a/aqua_voting_tracker/voting_rewards/tests/test_rewards.py
+++ b/aqua_voting_tracker/voting_rewards/tests/test_rewards.py
@@ -15,9 +15,25 @@ def get_markets(market_keys: Iterable[str]):
             'account_id': market_key,
             'asset1': f'A{i // 2 + 1}:ISSUER',
             'asset2': f'A{i // 2 + 2}:ISSUER',
+            'whitelisted_for_rewards': True,
         }
         for i, market_key in enumerate(market_keys)
     ]
+
+
+def make_get_markets(whitelist_flags: List[bool]):
+    def _builder(market_keys: Iterable[str]):
+        keys = list(market_keys)
+        return [
+            {
+                'account_id': market_key,
+                'asset1': f'A{i // 2 + 1}:ISSUER',
+                'asset2': f'A{i // 2 + 2}:ISSUER',
+                'whitelisted_for_rewards': whitelist_flags[i] if i < len(whitelist_flags) else False,
+            }
+            for i, market_key in enumerate(keys)
+        ]
+    return _builder
 
 
 def get_candidates(votes_value):
@@ -116,3 +132,83 @@ class GetCurrentRewardTestCase(TestCase):
             '0.1', '0.1', '0.1', '0.1', '0.1', '0.0909', '0.0606', '0.0606', '0.0303', '0.0303',
             '0.0303', '0.0303', '0.0303', '0.0303', '0.0303', '0.0303', '0.0152', '0.0152', '0.0152',
         ])
+
+    def test_whitelist_dilution(self):
+        # Non-whitelisted markets do not get rewards and their shares are NOT
+        # redistributed to survivors — total dispersion drops by their combined share.
+        candidates = get_candidates([95, 90, 85, 80, 75, 70, 65, 60, 55, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10])
+        stats = get_stats(candidates)  # full_voting_value = 1000
+
+        # Whitelist first 5 markets only: survivors_votes = 95+90+85+80+75 = 425, dilution = 0.425.
+        whitelist_flags = [True] * 5 + [False] * 14
+        survivors_share = Decimal('0.425')
+
+        with patch(self.get_candidates_patch, new=lambda x: candidates):
+            with patch(self.get_stats_patch, new=lambda: stats):
+                with patch(
+                    'aqua_voting_tracker.voting_rewards.services.rewards.base.get_market_pairs',
+                    new=make_get_markets(whitelist_flags),
+                ):
+                    rewards = RewardsV1Calculator().run()
+
+        self.assertEqual(len(rewards), 5)
+
+        # Per-pair share = votes / full_voting_value (no /total_share renormalization).
+        self.assert_shares(rewards, ['0.095', '0.09', '0.085', '0.08', '0.075'])
+
+        # Total dispersion = TOTAL_REWARDS * survivors_share (≈ 0.425 * 7M).
+        total_reward = sum(reward.reward_value for reward in rewards)
+        self.assertAlmostEqual(
+            total_reward,
+            settings.TOTAL_REWARD_VALUE * survivors_share,
+            delta=5,
+        )
+        self.assertLessEqual(total_reward, settings.TOTAL_REWARD_VALUE)
+
+        # Per-pair cap is absolute (REWARD_MAX_SHARE * TOTAL_REWARDS = 700k), not relative.
+        self.assertTrue(all(reward.share <= settings.REWARD_MAX_SHARE for reward in rewards))
+        self.assertTrue(all(
+            reward.reward_value <= settings.REWARD_MAX_SHARE * settings.TOTAL_REWARD_VALUE
+            for reward in rewards
+        ))
+
+    def test_whitelist_cap_redistribute(self):
+        # filter_eligible runs AFTER calculate_shares: cap+redistribute is computed
+        # over the full reward_zone (including non-whitelisted), then non-whitelisted
+        # markets are dropped — their final share is removed entirely, not dissolved
+        # back into survivors. Per-pair cap is 700k absolute (REWARD_MAX_SHARE * TOTAL_REWARDS).
+        # Votes [600, 200, 50, 50, 50, 50], denominator = 1000.
+        # First (600 votes) not whitelisted.
+        candidates = get_candidates([600, 200, 50, 50, 50, 50])
+        stats = get_stats(candidates)
+
+        whitelist_flags = [False, True, True, True, True, True]
+
+        with patch(self.get_candidates_patch, new=lambda x: candidates):
+            with patch(self.get_stats_patch, new=lambda: stats):
+                with patch(
+                    'aqua_voting_tracker.voting_rewards.services.rewards.base.get_market_pairs',
+                    new=make_get_markets(whitelist_flags),
+                ):
+                    rewards = RewardsV1Calculator().run()
+
+        self.assertEqual(len(rewards), 5)
+
+        # All 6 markets hit the 0.1 cap during calculate_shares (m1 base=0.6, m2 base=0.2;
+        # cut_share accumulates and pushes m3..m6 over the cap too). After dropping
+        # m1, survivors each retain their cap of 0.1.
+        self.assert_shares(rewards, ['0.1', '0.1', '0.1', '0.1', '0.1'])
+
+        # Total = 5 * 700k = 3.5M (= 0.5 * TOTAL_REWARDS); m1's 0.1 capped share is lost.
+        total_reward = sum(reward.reward_value for reward in rewards)
+        self.assertAlmostEqual(
+            total_reward,
+            settings.TOTAL_REWARD_VALUE * Decimal('0.5'),
+            delta=5,
+        )
+
+        # Per-pair cap is 700k absolute.
+        self.assertTrue(all(
+            reward.reward_value <= settings.REWARD_MAX_SHARE * settings.TOTAL_REWARD_VALUE
+            for reward in rewards
+        ))

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -99,7 +99,7 @@ if SENTRY_ENABLED:
 # Horizon configuration
 # --------------------------------------------------------------------------
 
-STELLAR_PASSPHRASE = 'Public Global Stellar Network ; September 2015'
+STELLAR_PASSPHRASE = env('STELLAR_PASSPHRASE', default='Public Global Stellar Network ; September 2015')
 HORIZON_URL = env('HORIZON_URL', default='https://horizon.stellar.org')
 
 


### PR DESCRIPTION
## Summary

- `RewardsCalculator.filter_eligible` drops market pairs whose `whitelisted_for_rewards` (sourced from marketkeys-tracker) is false. Runs **before** `calculate_shares`, so the share denominator is restricted to survivors — when few markets are whitelisted, each survivor naturally lifts to the `REWARD_MAX_SHARE` cap via cap+redistribute.
- `set_reward_value` no longer divides by `total_share`. The per-pair cap stays absolute at `REWARD_MAX_SHARE * TOTAL_REWARDS` (= 700k AQUA/day) and the total dispersion across survivors falls below `TOTAL_REWARDS` whenever cap+redistribute leaves any residue.
- `MarketReward` gains a `whitelisted_for_rewards` field populated in `connect_assets` from the `get_market_pairs` response.
- Pipeline order in `v1.py` and `v2.py`: `get_reward_zone → connect_assets → filter_eligible → calculate_shares → set_reward_value → distribute_sdex_amm…`.

## Test plan

- [x] `pytest aqua_voting_tracker/voting_rewards/tests/test_rewards.py` — 5/5 pass locally.
- [x] Existing `test_common` / `test_cut_to_limit1` / `test_cut_to_limit2` unchanged in expectations (all candidates whitelisted in mock; sum of shares = 1 so dropping `/total_share` is a no-op for them).
- [x] New `test_whitelist_few_survivors_lift_to_cap`: 5 of 19 markets whitelisted → each survivor lifts to the cap (0.1) → total = 5 × 700k = 3.5M, residue 0.5 is lost.
- [x] New `test_whitelist_cap_redistribute`: 5 survivors where the top one dominates votes; cap+redistribute spreads excess among the others and they all end at cap → total 3.5M.
- [ ] Verify against current testnet reward snapshot once deployed.